### PR TITLE
Security hardening: webhook token verification, auth bypass fix, credential cleanup, IAM least-privilege

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -30,6 +30,8 @@ logger = logging.getLogger(__name__)
 bot: Bot | None = None
 dp: Dispatcher = Dispatcher()
 db: firestore.Client | None = None
+webhook_secret: str | None = None
+authorized_user_id: str | None = None
 
 WEBHOOK_PATH = "/webhook"
 
@@ -196,6 +198,16 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         bot = Bot(token=token, default=DefaultBotProperties(parse_mode=ParseMode.HTML))
         logger.info("Bot instance created.")
 
+    global webhook_secret  # noqa: PLW0603
+    webhook_secret = get_secret("webhook-secret-token")
+    if not webhook_secret:
+        logger.warning("No webhook-secret-token configured. Webhook requests will not be verified.")
+
+    global authorized_user_id  # noqa: PLW0603
+    authorized_user_id = get_secret("authorized-user-id")
+    if not authorized_user_id:
+        logger.warning("No authorized-user-id configured. All users will be allowed.")
+
     yield
 
     logger.info("Shutting down FastAPI application...")
@@ -212,21 +224,31 @@ async def telegram_webhook(request: Request) -> dict[str, str]:
     if bot is None:
         raise HTTPException(status_code=500, detail="Bot not initialized")
 
+    # Verify the Telegram webhook secret token to reject requests not from Telegram
+    if webhook_secret:
+        incoming_secret = request.headers.get("X-Telegram-Bot-Api-Secret-Token")
+        if incoming_secret != webhook_secret:
+            raise HTTPException(status_code=403, detail="Forbidden")
+
     try:
         body = await request.json()
         update = Update(**body)
 
         # Authorization Check
-        authorized_id_str = get_secret("authorized-user-id")
         user_id = None
         if update.message and update.message.from_user:
             user_id = update.message.from_user.id
         elif update.callback_query and update.callback_query.from_user:
             user_id = update.callback_query.from_user.id
 
-        if authorized_id_str and user_id and str(user_id) != authorized_id_str:
-            logger.warning("Unauthorized access attempt from %s", user_id)
-            return {"status": "ok"}  # Return 200 OK so Telegram doesn't retry
+        if authorized_user_id:
+            # If an authorized user is configured, a resolvable user_id is required
+            if user_id is None:
+                logger.warning("Unauthorized access attempt: no user_id resolvable in update")
+                return {"status": "ok"}  # Return 200 OK so Telegram doesn't retry
+            if str(user_id) != authorized_user_id:
+                logger.warning("Unauthorized access attempt from user %s", user_id)
+                return {"status": "ok"}  # Return 200 OK so Telegram doesn't retry
 
         await dp.feed_update(bot=bot, update=update)
         return {"status": "ok"}

--- a/bot/main.py
+++ b/bot/main.py
@@ -201,7 +201,9 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     global webhook_secret  # noqa: PLW0603
     webhook_secret = get_secret("webhook-secret-token")
     if not webhook_secret:
-        logger.warning("No webhook-secret-token configured. Webhook requests will not be verified.")
+        logger.warning(
+            "No webhook-secret-token configured. Webhook requests will not be verified."
+        )
 
     global authorized_user_id  # noqa: PLW0603
     authorized_user_id = get_secret("authorized-user-id")
@@ -244,7 +246,9 @@ async def telegram_webhook(request: Request) -> dict[str, str]:
         if authorized_user_id:
             # If an authorized user is configured, a resolvable user_id is required
             if user_id is None:
-                logger.warning("Unauthorized access attempt: no user_id resolvable in update")
+                logger.warning(
+                    "Unauthorized access attempt: no user_id resolvable in update"
+                )
                 return {"status": "ok"}  # Return 200 OK so Telegram doesn't retry
             if str(user_id) != authorized_user_id:
                 logger.warning("Unauthorized access attempt from user %s", user_id)

--- a/bot/tests/test_bot.py
+++ b/bot/tests/test_bot.py
@@ -1,10 +1,9 @@
 import http
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import bot.main as bot_main
-import pytest
 from fastapi.testclient import TestClient
 
+import bot.main as bot_main
 from bot.main import app
 
 client = TestClient(app)
@@ -24,8 +23,9 @@ def test_health_check():
 
 def test_webhook_returns_403_with_wrong_secret():
     """Webhook must reject requests that carry a wrong secret token."""
-    with patch.object(bot_main, "bot", MagicMock()), patch.object(
-        bot_main, "webhook_secret", "correct-secret"
+    with (
+        patch.object(bot_main, "bot", MagicMock()),
+        patch.object(bot_main, "webhook_secret", "correct-secret"),
     ):
         response = client.post(
             "/webhook",
@@ -37,8 +37,9 @@ def test_webhook_returns_403_with_wrong_secret():
 
 def test_webhook_returns_403_with_missing_secret():
     """Webhook must reject requests that omit the secret token header."""
-    with patch.object(bot_main, "bot", MagicMock()), patch.object(
-        bot_main, "webhook_secret", "correct-secret"
+    with (
+        patch.object(bot_main, "bot", MagicMock()),
+        patch.object(bot_main, "webhook_secret", "correct-secret"),
     ):
         response = client.post("/webhook", json={"update_id": 1})
     assert response.status_code == http.HTTPStatus.FORBIDDEN

--- a/bot/tests/test_bot.py
+++ b/bot/tests/test_bot.py
@@ -1,5 +1,8 @@
 import http
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import bot.main as bot_main
+import pytest
 from fastapi.testclient import TestClient
 
 from bot.main import app
@@ -17,3 +20,110 @@ def test_health_check():
     response = client.get("/health")
     assert response.status_code == http.HTTPStatus.OK
     assert response.json() == {"status": "healthy"}
+
+
+def test_webhook_returns_403_with_wrong_secret():
+    """Webhook must reject requests that carry a wrong secret token."""
+    with patch.object(bot_main, "bot", MagicMock()), patch.object(
+        bot_main, "webhook_secret", "correct-secret"
+    ):
+        response = client.post(
+            "/webhook",
+            json={"update_id": 1},
+            headers={"X-Telegram-Bot-Api-Secret-Token": "wrong-secret"},
+        )
+    assert response.status_code == http.HTTPStatus.FORBIDDEN
+
+
+def test_webhook_returns_403_with_missing_secret():
+    """Webhook must reject requests that omit the secret token header."""
+    with patch.object(bot_main, "bot", MagicMock()), patch.object(
+        bot_main, "webhook_secret", "correct-secret"
+    ):
+        response = client.post("/webhook", json={"update_id": 1})
+    assert response.status_code == http.HTTPStatus.FORBIDDEN
+
+
+def test_webhook_returns_200_with_correct_secret():
+    """Webhook must accept requests that carry the correct secret token."""
+    mock_bot = MagicMock()
+    mock_dp = MagicMock()
+    mock_dp.feed_update = AsyncMock()
+
+    with (
+        patch.object(bot_main, "bot", mock_bot),
+        patch.object(bot_main, "webhook_secret", "correct-secret"),
+        patch.object(bot_main, "authorized_user_id", None),
+        patch.object(bot_main, "dp", mock_dp),
+    ):
+        response = client.post(
+            "/webhook",
+            json={"update_id": 1},
+            headers={"X-Telegram-Bot-Api-Secret-Token": "correct-secret"},
+        )
+    assert response.status_code == http.HTTPStatus.OK
+
+
+def test_webhook_passes_through_when_no_secret_configured():
+    """When no webhook_secret is configured the endpoint should not enforce the header."""
+    mock_bot = MagicMock()
+    mock_dp = MagicMock()
+    mock_dp.feed_update = AsyncMock()
+
+    with (
+        patch.object(bot_main, "bot", mock_bot),
+        patch.object(bot_main, "webhook_secret", None),
+        patch.object(bot_main, "authorized_user_id", None),
+        patch.object(bot_main, "dp", mock_dp),
+    ):
+        response = client.post("/webhook", json={"update_id": 1})
+    assert response.status_code == http.HTTPStatus.OK
+
+
+def test_webhook_rejects_unknown_user_when_auth_configured():
+    """Webhook must silently drop updates from users not matching authorized_user_id."""
+    mock_bot = MagicMock()
+    mock_dp = MagicMock()
+    mock_dp.feed_update = AsyncMock()
+
+    update_payload = {
+        "update_id": 2,
+        "message": {
+            "message_id": 1,
+            "date": 0,
+            "chat": {"id": 999, "type": "private"},
+            "from": {"id": 999, "is_bot": False, "first_name": "Evil"},
+        },
+    }
+
+    with (
+        patch.object(bot_main, "bot", mock_bot),
+        patch.object(bot_main, "webhook_secret", None),
+        patch.object(bot_main, "authorized_user_id", "111"),
+        patch.object(bot_main, "dp", mock_dp),
+    ):
+        response = client.post("/webhook", json=update_payload)
+
+    assert response.status_code == http.HTTPStatus.OK
+    mock_dp.feed_update.assert_not_called()
+
+
+def test_webhook_rejects_update_with_no_user_when_auth_configured():
+    """Webhook must drop updates with no resolvable user_id when authorized_user_id is set."""
+    mock_bot = MagicMock()
+    mock_dp = MagicMock()
+    mock_dp.feed_update = AsyncMock()
+
+    # An update with no message.from_user and no callback_query → user_id is None
+    update_payload = {"update_id": 3}
+
+    with (
+        patch.object(bot_main, "bot", mock_bot),
+        patch.object(bot_main, "webhook_secret", None),
+        patch.object(bot_main, "authorized_user_id", "111"),
+        patch.object(bot_main, "dp", mock_dp),
+    ):
+        response = client.post("/webhook", json=update_payload)
+
+    assert response.status_code == http.HTTPStatus.OK
+    mock_dp.feed_update.assert_not_called()

--- a/downloader/controller.py
+++ b/downloader/controller.py
@@ -121,10 +121,14 @@ class DownloaderManager:
         creds_file.write_text(f"{vpn_user}\n{vpn_pass}\n")
         creds_file.chmod(0o600)
 
-        # In production this would daemonize the OpenVPN client via Subprocess
-        logger.info("Starting OpenVPN tunnel...")
-        time.sleep(5)  # Let tunnel establish (mocked for now)
-        logger.info("VPN ready.")
+        try:
+            # In production this would daemonize the OpenVPN client via Subprocess
+            logger.info("Starting OpenVPN tunnel...")
+            time.sleep(5)  # Let tunnel establish (mocked for now)
+            logger.info("VPN ready.")
+        finally:
+            # Remove credentials file as soon as OpenVPN has started
+            creds_file.unlink(missing_ok=True)
 
     def _start_torrent(self) -> str:
         """Utilizes aria2c over a generic subprocess to torrent the magnet."""

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -3,6 +3,15 @@ provider "google" {
   region  = var.gcp_region
 }
 
+provider "random" {}
+
+# Generates a cryptographically secure random webhook secret used to verify
+# that incoming webhook requests originate from Telegram.
+resource "random_password" "webhook_secret" {
+  length  = 32
+  special = false
+}
+
 variable "gcp_project_id" {
   description = "The GCP Project ID"
   type        = string
@@ -70,6 +79,22 @@ resource "google_secret_manager_secret_version" "authorized_user_id_data" {
   secret_data = var.authorized_user_id
 }
 
+resource "google_secret_manager_secret" "webhook_secret_token" {
+  secret_id = "webhook-secret-token"
+  replication {
+    user_managed {
+      replicas {
+        location = var.gcp_region
+      }
+    }
+  }
+}
+
+resource "google_secret_manager_secret_version" "webhook_secret_token_data" {
+  secret      = google_secret_manager_secret.webhook_secret_token.id
+  secret_data = random_password.webhook_secret.result
+}
+
 resource "google_secret_manager_secret" "vpn_user" {
   count     = var.enable_vpn ? 1 : 0
   secret_id = "vpn-user"
@@ -116,8 +141,15 @@ resource "google_service_account" "downloader_sa" {
 # Bot needs to spin up VMs and read secrets
 resource "google_project_iam_member" "bot_compute_admin" {
   project = var.gcp_project_id
-  role    = "roles/compute.admin"
+  role    = "roles/compute.instanceAdmin.v1"
   member  = "serviceAccount:${google_service_account.bot_sa.email}"
+}
+
+# Downloader needs to delete its own Compute Engine instance
+resource "google_project_iam_member" "downloader_compute_instance_admin" {
+  project = var.gcp_project_id
+  role    = "roles/compute.instanceAdmin.v1"
+  member  = "serviceAccount:${google_service_account.downloader_sa.email}"
 }
 
 # Downloader needs to read secrets, write to GCS, and delete itself


### PR DESCRIPTION
The bot's webhook endpoint had no origin verification, a bypassable user-auth check, lingering VPN credentials on disk, and an over-privileged service account IAM role.

## Changes

### `bot/main.py` — Webhook & authorization hardening
- **Webhook secret verification:** Load `webhook-secret-token` from Secret Manager once at startup; reject requests missing or mismatching the `X-Telegram-Bot-Api-Secret-Token` header with HTTP 403.
- **Auth bypass fix:** Old guard `if authorized_id_str and user_id and ...` silently passed updates with no resolvable `user_id` (channel posts, service messages). Now any update where `user_id` is `None` is dropped when `authorized_user_id` is configured.
- **Secret caching:** Both `webhook_secret` and `authorized_user_id` are fetched once in `lifespan()` instead of on every request.

```python
# Before — bypassed when user_id is None
if authorized_id_str and user_id and str(user_id) != authorized_id_str:
    ...

# After — None user_id is explicitly rejected
if authorized_user_id:
    if user_id is None:
        logger.warning("Unauthorized access attempt: no user_id resolvable in update")
        return {"status": "ok"}
    if str(user_id) != authorized_user_id:
        logger.warning("Unauthorized access attempt from user %s", user_id)
        return {"status": "ok"}
```

### `downloader/controller.py` — VPN credential cleanup
`creds.txt` was written to disk and never deleted. Wrapped the OpenVPN start block in `try/finally` to call `creds_file.unlink(missing_ok=True)` as soon as the tunnel is up.

### `infra/main.tf` — IAM least-privilege + webhook secret provisioning
- Downgraded bot SA from `roles/compute.admin` → `roles/compute.instanceAdmin.v1`.
- Added `roles/compute.instanceAdmin.v1` to the downloader SA (was missing; self-deletion would have failed).
- Added `webhook-secret-token` Secret Manager secret, auto-populated with a Terraform-generated `random_password`.

<!-- START COPILOT CODING AGENT SUFFIX -->



<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> perform a security review of the code.


</details>



<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/emptymalei/Pfirsichfest/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
