### PR TITLE
feat(database): add DatabaseClient abstraction with in-memory mock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,9 @@ TELEGRAM_BOT_TOKEN=123456789:your-token-here
 AUTHORIZED_USER_ID=123456789
 
 # --- Core Platform Settings ---
-# Google Cloud Project ID where the infrastructure will deploy
+# Google Cloud Project ID where the infrastructure will deploy.
+# Leave as 'your-gcp-project-id' or unset to use an in-memory database mock
+# for local development (no GCP credentials required).
 GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 # Google Cloud Region/Zone
 GOOGLE_CLOUD_REGION=us-central1

--- a/bot/README.md
+++ b/bot/README.md
@@ -8,7 +8,28 @@ This module contains the Telegram Bot API Webhook service. It is designed to be 
 3.  **State Management:** Stores temporary request metadata into Google `firestore`.
 4.  **Compute Integrations:** Contains `compute_helper.py` which dynamically invokes the Google Cloud Compute engine API to spin up the downstream Ephemeral Spot VMs defined in `/downloader`.
 
+## Local Development
+
+When running locally without a valid `GOOGLE_CLOUD_PROJECT`, the bot
+automatically uses an **in-memory database mock** instead of Google
+Firestore. This allows all database-dependent features (`/status`,
+`/download` tracking) to work out of the box, with no GCP credentials
+required.
+
+The mock is implemented via a `DatabaseClient` protocol in
+`database.py`, with an `InMemoryDatabaseClient` backed by a plain
+Python `dict`. Data is held in memory and lost on restart, which is
+fine for development and testing.
+
 ## Setup
 It relies on Conda for dependencies (`environment.yml`). 
 Required Secrets in Google Secret Manager to function:
 - `telegram-bot-token`
+
+## Testing
+
+Run the test suite from the repository root:
+
+```bash
+python -m pytest bot/tests/ -v
+```

--- a/bot/database.py
+++ b/bot/database.py
@@ -1,0 +1,201 @@
+"""Database abstraction layer for Pfirsichfest Bot.
+
+Provides a Protocol-based interface for Firestore-compatible operations
+and an in-memory implementation for local development and testing.
+"""
+
+from __future__ import annotations
+
+import logging
+import operator
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# Operator dispatch table used by InMemoryQuery.stream
+_OPS: dict[str, Callable[[Any, Any], bool]] = {
+    "==": operator.eq,
+    "!=": operator.ne,
+    "<": operator.lt,
+    "<=": operator.le,
+    ">": operator.gt,
+    ">=": operator.ge,
+}
+
+
+def _no_match(_a: Any, _b: Any) -> bool:
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Protocol definitions — matches the Firestore API surface we actually use
+# ---------------------------------------------------------------------------
+
+
+class DocumentSnapshot(Protocol):
+    """A snapshot of a single document."""
+
+    @property
+    def id(self) -> str: ...
+
+    def to_dict(self) -> dict[str, Any] | None: ...
+
+
+class DocumentReference(Protocol):
+    """A reference to a single document in a collection."""
+
+    def set(self, data: dict[str, Any]) -> Any: ...
+
+    def update(self, data: dict[str, Any]) -> Any: ...
+
+
+class Query(Protocol):
+    """A query that can be streamed."""
+
+    def stream(self) -> Any: ...
+
+
+class CollectionReference(Protocol):
+    """A reference to a collection of documents."""
+
+    def document(self, doc_id: str) -> DocumentReference: ...
+
+    def where(self, field: str, op: str, value: Any) -> Query: ...
+
+
+@runtime_checkable
+class DatabaseClient(Protocol):
+    """Minimal database client interface matching Firestore usage."""
+
+    def collection(self, name: str) -> CollectionReference: ...
+
+
+# ---------------------------------------------------------------------------
+# In-memory implementation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InMemoryDocumentSnapshot:
+    """In-memory implementation of a Firestore-like document snapshot."""
+
+    _id: str
+    _data: dict[str, Any] | None
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    def to_dict(self) -> dict[str, Any] | None:
+        return dict(self._data) if self._data else None
+
+
+@dataclass
+class InMemoryDatabaseClient:
+    """In-memory dict-backed implementation of DatabaseClient.
+
+    Useful for local development and testing without a real Firestore instance.
+    Data is held in memory and lost on process restart.
+    """
+
+    store: dict[str, dict[str, dict[str, Any]]] = field(default_factory=dict)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def collection(self, name: str) -> InMemoryCollectionReference:
+        with self.lock:
+            if name not in self.store:
+                self.store[name] = {}
+        return InMemoryCollectionReference(client=self, name=name)
+
+
+@dataclass
+class InMemoryDocumentReference:
+    """In-memory implementation of a Firestore-like document reference."""
+
+    client: InMemoryDatabaseClient
+    col_name: str
+    doc_id: str
+
+    def set(self, data: dict[str, Any]) -> None:
+        with self.client.lock:
+            self.client.store[self.col_name][self.doc_id] = dict(data)
+
+    def update(self, data: dict[str, Any]) -> None:
+        with self.client.lock:
+            store = self.client.store
+            if self.col_name in store and self.doc_id in store[self.col_name]:
+                store[self.col_name][self.doc_id].update(data)
+            else:
+                # Firestore update on non-existent doc raises; we just set it
+                store[self.col_name][self.doc_id] = dict(data)
+
+
+@dataclass
+class InMemoryQuery:
+    """In-memory implementation of a Firestore-like query."""
+
+    client: InMemoryDatabaseClient
+    col_name: str
+    field_name: str
+    op: str
+    value: Any
+
+    def stream(self) -> list[InMemoryDocumentSnapshot]:
+        with self.client.lock:
+            docs = self.client.store.get(self.col_name, {})
+            cmp = _OPS.get(self.op, _no_match)
+            return [
+                InMemoryDocumentSnapshot(_id=doc_id, _data=data)
+                for doc_id, data in docs.items()
+                if cmp(data.get(self.field_name), self.value)
+            ]
+
+
+@dataclass
+class InMemoryCollectionReference:
+    """In-memory implementation of a Firestore-like collection reference."""
+
+    client: InMemoryDatabaseClient
+    name: str
+
+    def document(self, doc_id: str) -> InMemoryDocumentReference:
+        return InMemoryDocumentReference(
+            client=self.client, col_name=self.name, doc_id=doc_id
+        )
+
+    def where(self, field: str, op: str, value: Any) -> InMemoryQuery:
+        return InMemoryQuery(
+            client=self.client,
+            col_name=self.name,
+            field_name=field,
+            op=op,
+            value=value,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def create_database_client(project_id: str | None) -> DatabaseClient:
+    """Creates the appropriate database client based on configuration.
+
+    If a valid GCP project ID is provided, returns a real Firestore client.
+    Otherwise, returns an in-memory mock for local development.
+    """
+    if project_id and project_id != "your-gcp-project-id":
+        from google.cloud import firestore  # type: ignore[import-untyped]  # noqa: PLC0415, I001
+
+        client = firestore.Client(project=project_id)
+        logger.info("Firestore client initialized for project '%s'.", project_id)
+        return client  # type: ignore[return-value]
+
+    logger.info(
+        "No valid GOOGLE_CLOUD_PROJECT set. "
+        "Using in-memory database for local development."
+    )
+    return InMemoryDatabaseClient()

--- a/bot/main.py
+++ b/bot/main.py
@@ -16,11 +16,11 @@ from aiogram.types import Update
 from dotenv import load_dotenv  # type: ignore[import-untyped]
 from fastapi import FastAPI, HTTPException, Request
 from google.cloud import (
-    firestore,  # type: ignore[import-untyped]
     secretmanager,  # type: ignore[import-untyped]
 )
 
 from .compute_helper import SpotVMProvisioner
+from .database import DatabaseClient, create_database_client
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, stream=sys.stdout)
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 # Globals to hold our uninstantiated clients until startup
 bot: Bot | None = None
 dp: Dispatcher = Dispatcher()
-db: firestore.Client | None = None
+db: DatabaseClient | None = None
 
 WEBHOOK_PATH = "/webhook"
 
@@ -182,11 +182,7 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
 
     global db  # noqa: PLW0603
     gcp_project = os.environ.get("GOOGLE_CLOUD_PROJECT", "")
-    if gcp_project and gcp_project != "your-gcp-project-id":
-        db = firestore.Client(project=gcp_project)
-        logger.info("Firestore client initialized for %s.", gcp_project)
-    else:
-        logger.warning("No valid GOOGLE_CLOUD_PROJECT set. Running without Firestore.")
+    db = create_database_client(gcp_project or None)
 
     global bot  # noqa: PLW0603
     token = get_secret("telegram-bot-token")

--- a/bot/tests/test_database.py
+++ b/bot/tests/test_database.py
@@ -1,0 +1,155 @@
+# ruff: noqa: PLR2004
+"""Tests for the database abstraction layer."""
+
+from bot.database import InMemoryDatabaseClient, create_database_client
+
+
+class TestInMemoryDatabaseClient:
+    """Tests for InMemoryDatabaseClient."""
+
+    def test_set_and_get_document(self):
+        """Documents stored with set() can be retrieved via where().stream()."""
+        db = InMemoryDatabaseClient()
+        db.collection("downloads").document("doc1").set(
+            {"chat_id": 123, "status": "provisioning_vm", "magnet": "magnet:?xt=..."}
+        )
+        results = list(
+            db.collection("downloads").where("status", "==", "provisioning_vm").stream()
+        )
+        assert len(results) == 1
+        assert results[0].id == "doc1"
+        data = results[0].to_dict()
+        assert data is not None
+        assert data["chat_id"] == 123
+        assert data["status"] == "provisioning_vm"
+
+    def test_update_document(self):
+        """update() merges fields into an existing document."""
+        db = InMemoryDatabaseClient()
+        db.collection("downloads").document("doc1").set(
+            {"status": "provisioning_vm", "magnet": "magnet:?xt=..."}
+        )
+        db.collection("downloads").document("doc1").update({"status": "downloading"})
+
+        results = list(
+            db.collection("downloads").where("status", "==", "downloading").stream()
+        )
+        assert len(results) == 1
+        data = results[0].to_dict()
+        assert data is not None
+        assert data["magnet"] == "magnet:?xt=..."
+
+    def test_update_nonexistent_document(self):
+        """update() on a non-existent document creates it (graceful fallback)."""
+        db = InMemoryDatabaseClient()
+        db.collection("downloads").document("doc1").update({"status": "downloading"})
+
+        results = list(
+            db.collection("downloads").where("status", "==", "downloading").stream()
+        )
+        assert len(results) == 1
+
+    def test_where_not_equal(self):
+        """where() supports the != operator."""
+        db = InMemoryDatabaseClient()
+        db.collection("downloads").document("doc1").set({"status": "completed"})
+        db.collection("downloads").document("doc2").set({"status": "downloading"})
+        db.collection("downloads").document("doc3").set({"status": "provisioning_vm"})
+
+        results = list(
+            db.collection("downloads").where("status", "!=", "completed").stream()
+        )
+        assert len(results) == 2
+        ids = {r.id for r in results}
+        assert ids == {"doc2", "doc3"}
+
+    def test_where_no_matches(self):
+        """where() returns empty list when no documents match."""
+        db = InMemoryDatabaseClient()
+        db.collection("downloads").document("doc1").set({"status": "completed"})
+
+        results = list(
+            db.collection("downloads").where("status", "==", "downloading").stream()
+        )
+        assert len(results) == 0
+
+    def test_empty_collection(self):
+        """Querying an empty collection returns no results."""
+        db = InMemoryDatabaseClient()
+        results = list(
+            db.collection("nonexistent").where("field", "==", "value").stream()
+        )
+        assert len(results) == 0
+
+    def test_multiple_collections(self):
+        """Documents in different collections are isolated."""
+        db = InMemoryDatabaseClient()
+        db.collection("downloads").document("d1").set({"status": "active"})
+        db.collection("uploads").document("u1").set({"status": "active"})
+
+        downloads = list(
+            db.collection("downloads").where("status", "==", "active").stream()
+        )
+        uploads = list(
+            db.collection("uploads").where("status", "==", "active").stream()
+        )
+        assert len(downloads) == 1
+        assert downloads[0].id == "d1"
+        assert len(uploads) == 1
+        assert uploads[0].id == "u1"
+
+    def test_to_dict_returns_copy(self):
+        """to_dict() returns a copy so mutations don't affect the store."""
+        db = InMemoryDatabaseClient()
+        db.collection("downloads").document("doc1").set({"status": "active"})
+
+        results = list(
+            db.collection("downloads").where("status", "==", "active").stream()
+        )
+        data = results[0].to_dict()
+        assert data is not None
+        data["status"] = "tampered"
+
+        # Original should be unchanged
+        results2 = list(
+            db.collection("downloads").where("status", "==", "active").stream()
+        )
+        assert len(results2) == 1
+
+    def test_comparison_operators(self):
+        """where() supports <, <=, >, >= operators."""
+        db = InMemoryDatabaseClient()
+        db.collection("scores").document("a").set({"score": 10})
+        db.collection("scores").document("b").set({"score": 20})
+        db.collection("scores").document("c").set({"score": 30})
+
+        gt = list(db.collection("scores").where("score", ">", 15).stream())
+        assert len(gt) == 2
+
+        gte = list(db.collection("scores").where("score", ">=", 20).stream())
+        assert len(gte) == 2
+
+        lt = list(db.collection("scores").where("score", "<", 20).stream())
+        assert len(lt) == 1
+
+        lte = list(db.collection("scores").where("score", "<=", 20).stream())
+        assert len(lte) == 2
+
+
+class TestCreateDatabaseClient:
+    """Tests for the factory function."""
+
+    def test_returns_in_memory_for_none(self):
+        """Returns InMemoryDatabaseClient when project_id is None."""
+        client = create_database_client(None)
+        assert isinstance(client, InMemoryDatabaseClient)
+
+    def test_returns_in_memory_for_placeholder(self):
+        """Returns InMemoryDatabaseClient for the placeholder project ID."""
+        client = create_database_client("your-gcp-project-id")
+        assert isinstance(client, InMemoryDatabaseClient)
+
+    def test_returns_in_memory_for_empty_string(self):
+        """Returns InMemoryDatabaseClient for empty string (falsy)."""
+        client = create_database_client("")
+        assert isinstance(client, InMemoryDatabaseClient)


### PR DESCRIPTION
> [!NOTE]
> This PR was created by **Claude** (Anthropic) on behalf of the user.

## Summary

Introduces a **Protocol-based `DatabaseClient` interface** that matches the Firestore API surface used by the bot, along with an **`InMemoryDatabaseClient`** backed by a Python dict for local development and testing.

When running locally without a valid `GOOGLE_CLOUD_PROJECT`, the bot now automatically uses the in-memory mock instead of leaving `db = None`. This means:
- `/status` returns proper results (not the "Database connection not initialized" error)
- `/download` persists download metadata to the mock DB

### Changes

| File | Description |
|---|---|
| `bot/database.py` | **New** — `DatabaseClient` Protocol + `InMemoryDatabaseClient` + `create_database_client()` factory |
| `bot/main.py` | Use factory; changed `db` type from `firestore.Client \| None` to `DatabaseClient \| None` |
| `bot/tests/test_database.py` | **New** — 12 unit tests for all in-memory operations |
| `.env.example` | Updated docs on local DB behavior |
| `bot/README.md` | Added Local Development and Testing sections |

### Design Decisions
- **Protocol over ABC**: More Pythonic; the real `firestore.Client` satisfies it via structural subtyping
- **`operator` module**: Used instead of lambdas to satisfy pyright strict mode
- **Deferred Firestore import**: The `google.cloud.firestore` import only happens when a real GCP project is configured, so local dev never needs GCP SDK
- **Zero new dependencies**: Works with the existing conda environment as-is

### Testing
All 14 tests pass. All pre-commit hooks (ruff check, ruff format, pyright strict) pass.

Closes #2